### PR TITLE
Add date-filter search tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,16 +70,21 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/sweng/nota_bene/repository/NoteRepository.java
+++ b/src/main/java/com/sweng/nota_bene/repository/NoteRepository.java
@@ -2,6 +2,7 @@ package com.sweng.nota_bene.repository;
 
 import java.util.List;
 import java.util.UUID;
+import java.time.LocalDateTime;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -36,6 +37,24 @@ public interface NoteRepository extends JpaRepository<Note, UUID> {
            "WHERE n.proprietario = :emailUtente OR c.emailUtente = :emailUtente " +
            "ORDER BY n.dataUltimaModifica DESC")
     List<Note> findAccessibleNotes(@Param("emailUtente") String emailUtente);
+
+    /**
+     * Cerca le note accessibili a un utente applicando filtri facoltativi su date
+     * di creazione e ultima modifica.
+     */
+    @Query("SELECT DISTINCT n FROM Note n LEFT JOIN Condivisione c ON n.id = c.idNota " +
+           "WHERE (n.proprietario = :emailUtente OR c.emailUtente = :emailUtente) " +
+           "AND (:createdFrom IS NULL OR n.dataCreazione >= :createdFrom) " +
+           "AND (:createdTo IS NULL OR n.dataCreazione <= :createdTo) " +
+           "AND (:modifiedFrom IS NULL OR n.dataUltimaModifica >= :modifiedFrom) " +
+           "AND (:modifiedTo IS NULL OR n.dataUltimaModifica <= :modifiedTo) " +
+           "ORDER BY n.dataUltimaModifica DESC")
+    List<Note> searchAccessibleNotes(
+            @Param("emailUtente") String emailUtente,
+            @Param("createdFrom") LocalDateTime createdFrom,
+            @Param("createdTo") LocalDateTime createdTo,
+            @Param("modifiedFrom") LocalDateTime modifiedFrom,
+            @Param("modifiedTo") LocalDateTime modifiedTo);
     
     /**
      * Trova le note condivise con un utente specifico

--- a/src/main/java/com/sweng/nota_bene/service/NoteService.java
+++ b/src/main/java/com/sweng/nota_bene/service/NoteService.java
@@ -3,6 +3,7 @@ package com.sweng.nota_bene.service;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,6 +77,21 @@ public class NoteService {
         tutteLeNote.sort((a, b) -> b.getDataUltimaModifica().compareTo(a.getDataUltimaModifica()));
         
         return tutteLeNote.stream()
+                .map(this::mapToNoteListResponse)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Ricerca le note accessibili applicando filtri facoltativi sulle date di
+     * creazione e modifica.
+     */
+    public List<NoteListResponse> searchAccessibleNotes(String emailUtente,
+            LocalDateTime createdFrom,
+            LocalDateTime createdTo,
+            LocalDateTime modifiedFrom,
+            LocalDateTime modifiedTo) {
+        List<Note> note = noteRepository.searchAccessibleNotes(emailUtente, createdFrom, createdTo, modifiedFrom, modifiedTo);
+        return note.stream()
                 .map(this::mapToNoteListResponse)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/sweng/nota_bene/repository/NoteRepositoryTest.java
+++ b/src/test/java/com/sweng/nota_bene/repository/NoteRepositoryTest.java
@@ -1,0 +1,114 @@
+package com.sweng.nota_bene.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.sweng.nota_bene.model.Condivisione;
+import com.sweng.nota_bene.model.Note;
+
+@DataJpaTest
+class NoteRepositoryTest {
+
+    @Autowired
+    private NoteRepository noteRepository;
+
+    @Autowired
+    private CondivisioneRepository condivisioneRepository;
+
+    @Autowired
+    private jakarta.persistence.EntityManager entityManager;
+
+    private static final String USER = "user@test.com";
+    private static final String OTHER = "other@test.com";
+
+    private Note noteA;
+    private Note noteB;
+    private Note noteC;
+
+    @BeforeEach
+    void setup() {
+        condivisioneRepository.deleteAll();
+        noteRepository.deleteAll();
+
+        noteA = new Note();
+        noteA.setTitolo("A");
+        noteA.setContenuto("A");
+        noteA.setProprietario(USER);
+        persistWithDates(noteA, LocalDateTime.of(2023, 1, 1, 0, 0), LocalDateTime.of(2023, 1, 10, 0, 0));
+
+        noteB = new Note();
+        noteB.setTitolo("B");
+        noteB.setContenuto("B");
+        noteB.setProprietario(OTHER);
+        persistWithDates(noteB, LocalDateTime.of(2023, 2, 1, 0, 0), LocalDateTime.of(2023, 2, 10, 0, 0));
+        condivisioneRepository.save(new Condivisione(noteB.getId(), USER, Condivisione.TipoCondivisione.lettura));
+
+        noteC = new Note();
+        noteC.setTitolo("C");
+        noteC.setContenuto("C");
+        noteC.setProprietario(USER);
+        persistWithDates(noteC, LocalDateTime.of(2023, 3, 1, 0, 0), LocalDateTime.of(2023, 3, 10, 0, 0));
+    }
+
+    private void persistWithDates(Note note, LocalDateTime created, LocalDateTime modified) {
+        noteRepository.save(note);
+        entityManager.flush();
+        entityManager.createNativeQuery("UPDATE nota SET data_creazione = ?, data_ultima_modifica = ? WHERE id = ?")
+                .setParameter(1, Timestamp.valueOf(created))
+                .setParameter(2, Timestamp.valueOf(modified))
+                .setParameter(3, note.getId())
+                .executeUpdate();
+        entityManager.clear();
+    }
+
+    @Test
+    void searchByCreatedFrom() {
+        List<Note> result = noteRepository.searchAccessibleNotes(USER,
+                LocalDateTime.of(2023, 2, 1, 0, 0), null, null, null);
+        assertEquals(List.of(noteC.getId(), noteB.getId()),
+                result.stream().map(Note::getId).toList());
+    }
+
+    @Test
+    void searchByCreatedTo() {
+        List<Note> result = noteRepository.searchAccessibleNotes(USER,
+                null, LocalDateTime.of(2023, 2, 28, 23, 59), null, null);
+        assertEquals(List.of(noteB.getId(), noteA.getId()),
+                result.stream().map(Note::getId).toList());
+    }
+
+    @Test
+    void searchByModifiedFrom() {
+        List<Note> result = noteRepository.searchAccessibleNotes(USER,
+                null, null, LocalDateTime.of(2023, 3, 1, 0, 0), null);
+        assertEquals(List.of(noteC.getId()),
+                result.stream().map(Note::getId).toList());
+    }
+
+    @Test
+    void searchByModifiedTo() {
+        List<Note> result = noteRepository.searchAccessibleNotes(USER,
+                null, null, null, LocalDateTime.of(2023, 2, 9, 0, 0));
+        assertEquals(List.of(noteA.getId()),
+                result.stream().map(Note::getId).toList());
+    }
+
+    @Test
+    void searchByCreatedAndModifiedRange() {
+        List<Note> result = noteRepository.searchAccessibleNotes(USER,
+                LocalDateTime.of(2023, 2, 1, 0, 0),
+                LocalDateTime.of(2023, 2, 15, 0, 0),
+                LocalDateTime.of(2023, 2, 1, 0, 0),
+                LocalDateTime.of(2023, 3, 5, 0, 0));
+        assertEquals(List.of(noteB.getId()),
+                result.stream().map(Note::getId).toList());
+    }
+}

--- a/src/test/java/com/sweng/nota_bene/service/NoteServiceSearchTest.java
+++ b/src/test/java/com/sweng/nota_bene/service/NoteServiceSearchTest.java
@@ -1,0 +1,59 @@
+package com.sweng.nota_bene.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sweng.nota_bene.dto.NoteListResponse;
+import com.sweng.nota_bene.model.Note;
+import com.sweng.nota_bene.repository.NoteRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NoteServiceSearchTest {
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @Mock
+    private TagService tagService;
+
+    @Mock
+    private CondivisioneService condivisioneService;
+
+    @InjectMocks
+    private NoteService noteService;
+
+    @Test
+    void searchAccessibleNotesReturnsMappedResults() {
+        String email = "user@test.com";
+        LocalDateTime createdFrom = LocalDateTime.of(2023, 1, 1, 0, 0);
+        LocalDateTime createdTo = LocalDateTime.of(2023, 12, 31, 0, 0);
+        LocalDateTime modifiedFrom = LocalDateTime.of(2023, 2, 1, 0, 0);
+        LocalDateTime modifiedTo = LocalDateTime.of(2023, 2, 28, 0, 0);
+
+        Note note = new Note();
+        note.setId(UUID.randomUUID());
+        note.setTitolo("Titolo");
+        note.setContenuto("Contenuto");
+        note.setProprietario(email);
+
+        when(noteRepository.searchAccessibleNotes(email, createdFrom, createdTo, modifiedFrom, modifiedTo))
+                .thenReturn(List.of(note));
+
+        List<NoteListResponse> result = noteService.searchAccessibleNotes(email, createdFrom, createdTo, modifiedFrom, modifiedTo);
+
+        assertEquals(1, result.size());
+        assertEquals("Titolo", result.get(0).titolo());
+        verify(noteRepository).searchAccessibleNotes(email, createdFrom, createdTo, modifiedFrom, modifiedTo);
+    }
+}


### PR DESCRIPTION
## Summary
- add H2 dependency for repository tests
- extend NoteRepository with `searchAccessibleNotes` supporting creation and modification date filters
- expose corresponding service method and tests verifying date combinations

## Testing
- `mvn -e -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b75ce3dd3c832c91c12592ca1d98c8