### PR TITLE
Use accessible Spring Boot parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+                <version>3.3.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sweng</groupId>


### PR DESCRIPTION
## Summary
- update the Spring Boot parent POM to version 3.3.4 to rely on an available release

## Testing
- mvn -q test *(fails: dependency downloads blocked by HTTP 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69295a084b8c832c9931972c980517e8)